### PR TITLE
Refactor tangent testing utils

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt and contributors"]
-version = "0.1.0"
+version = "0.1.2"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
There is presently quite a bit of code-duplication in the tangent tests. Given that I'm about to refactor this interface, it makes sense to tidy it up to make refactoring as painless as possible.