### PR TITLE
More safety checks for interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -12,4 +12,9 @@
             @test _dx isa tangent_type(typeof(_x))
         end
     end
+    @testset "sensible error when CoDuals are passed to `value_and_pullback!!" begin
+        foo(x) = sin(cos(x))
+        rule = build_rrule(foo, 5.0)
+        @test_throws ArgumentError value_and_pullback!!(rule, 1.0, foo, CoDual(5.0, 0.0))
+    end
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Adds some static checks to the `__value_and_pullback!!` interface to prevent accidentally calling a DerivedRule with incorrect arguments.