### PR TITLE
Tackle bitcast and fastmath

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -89,6 +89,7 @@ end
 
 @intrinsic bitcast
 function rrule!!(f::CoDual{typeof(bitcast)}, t::CoDual{Type{T}}, x) where {T}
+    T === Float64 && error("Hmmmmmmmmmmmm")
     _x = primal(x)
     v = bitcast(T, _x)
     if T <: Ptr && _x isa Ptr

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -89,7 +89,14 @@ end
 
 @intrinsic bitcast
 function rrule!!(f::CoDual{typeof(bitcast)}, t::CoDual{Type{T}}, x) where {T}
-    T === Float64 && error("Hmmmmmmmmmmmm")
+    if T <: IEEEFloat
+        msg = "It is not permissible to bitcast to a differentiable type during AD, as " *
+        "this risks dropping tangents, and therefore risks silently giving the wrong " *
+        "answer. If this call to bitcast appears as part of the implementation of a " *
+        "differentiable function, you should write a rule for this function, or modify " *
+        "its implementation to avoid the bitcast."
+        throw(ArgumentError(msg))
+    end
     _x = primal(x)
     v = bitcast(T, _x)
     if T <: Ptr && _x isa Ptr
@@ -670,7 +677,6 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:builtins})
         # atomic_pointerreplace -- NEEDS IMPLEMENTING AND TESTING
         # atomic_pointerset -- NEEDS IMPLEMENTING AND TESTING
         # atomic_pointerswap -- NEEDS IMPLEMENTING AND TESTING
-        (false, :stability, nothing, IntrinsicsWrappers.bitcast, Float64, 5),
         (false, :stability, nothing, IntrinsicsWrappers.bitcast, Int64, 5.0),
         (false, :stability, nothing, IntrinsicsWrappers.bswap_int, 5),
         (false, :stability, nothing, IntrinsicsWrappers.ceil_llvm, 4.1),

--- a/test/rrules/builtins.jl
+++ b/test/rrules/builtins.jl
@@ -10,4 +10,11 @@
     )
 
     TestUtils.run_rrule!!_test_cases(StableRNG, Val(:builtins))
+
+    @testset "Disable bitcast to differentiable type" begin
+        @test_throws(
+            ArgumentError,
+            rrule!!(zero_fcodual(bitcast), zero_fcodual(Float64), zero_fcodual(5))
+        )
+    end
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
This PR targets (what I see as) the central issue in https://github.com/withbayes/Tapir.jl/issues/114 -- `bitcast` drops important gradient information in the implementation of `Base.FastMath.exp_fast`. So solve this, I'm outlawing differentiation through `bitcast` when someone tries to cast _into_ a differentiable primitive type (`IEEEFloat`).

The second phase of this PR is to add rules for all of the functions in `Base.FastMaths`. ChainRules has rules for these, and I'd rather not copy + paste the code, so I _suspect_ that I'm going to have to add a dependency on ChainRules.