### PR TITLE
Compute CFG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.14"
+version = "0.2.15"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/bbcode.jl
+++ b/src/interpreter/bbcode.jl
@@ -486,6 +486,7 @@ function CC.IRCode(bb_code::BBCode)
     bb_code = _remove_double_edges(bb_code)
     insts = _ids_to_line_positions(bb_code)
     # cfg = _compute_basic_blocks(insts)
+    cfg =  control_flow_graph(bb_code)
     insts = _lines_to_blocks(insts, cfg)
     return IRCode(
         CC.InstructionStream(
@@ -495,7 +496,7 @@ function CC.IRCode(bb_code::BBCode)
             map(x -> x.line, insts),
             map(x -> x.flag, insts),
         ),
-        control_flow_graph(bb_code),
+        cfg,
         CC.copy(bb_code.linetable),
         CC.copy(bb_code.argtypes),
         CC.copy(bb_code.meta),

--- a/src/interpreter/bbcode.jl
+++ b/src/interpreter/bbcode.jl
@@ -485,7 +485,6 @@ function CC.IRCode(bb_code::BBCode)
     bb_code = _lower_switch_statements(bb_code)
     bb_code = _remove_double_edges(bb_code)
     insts = _ids_to_line_positions(bb_code)
-    # cfg = _compute_basic_blocks(insts)
     cfg =  control_flow_graph(bb_code)
     insts = _lines_to_blocks(insts, cfg)
     return IRCode(

--- a/test/interpreter/bbcode.jl
+++ b/test/interpreter/bbcode.jl
@@ -53,6 +53,16 @@ end
         @test length(Tapir.collect_stmts(bb_code)) == length(ir.stmts.inst)
         @test Tapir.id_to_line_map(bb_code) isa Dict{ID, Int}
     end
+    @testset "control_flow_graph" begin
+        ir = Base.code_ircode_by_type(Tuple{typeof(sin), Float64})[1][1]
+        bb = BBCode(ir)
+        new_ir = Core.Compiler.IRCode(bb)
+        cfg = Tapir.control_flow_graph(bb)
+        @test all(map((l, r) -> l.stmts == r.stmts, ir.cfg.blocks, cfg.blocks))
+        @test all(map((l, r) -> sort(l.preds) == sort(r.preds), ir.cfg.blocks, cfg.blocks))
+        @test all(map((l, r) -> sort(l.succs) == sort(r.succs), ir.cfg.blocks, cfg.blocks))
+        @test ir.cfg.index == cfg.index
+    end
     @testset "_characterise_unique_predecessor_blocks" begin
         @testset "single block" begin
             blk_id = ID()


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
The `Core.Compiler.CFG` object that `IRCode`s make use of ought to be trivial to compute from a `BBCode`. I'm trying this out to see if it actually is. It's quite helpful to have quick access to it, because there are some algorithms in `Core.Compiler` which do stuff with the CFG, e.g. compute the domtree.

