### PR TITLE
More fixes for SimpleVarInfo for large models

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.18"
+version = "0.2.19"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/TapirCUDAExt.jl
+++ b/ext/TapirCUDAExt.jl
@@ -46,6 +46,12 @@ module TapirCUDAExt
         m[k] = v
         return m
     end
+    function Tapir._verify_fdata_value(p::CuArray, f::CuArray)
+        if size(p) != size(f)
+            throw(InvalidFDataException("p has size $(size(p)) but f has size $(size(f))"))
+        end
+        return nothing
+    end
 
     # Basic rules for operating on CuArrays.
 

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -324,7 +324,9 @@ obtained from `P` alone.
 @generated function can_produce_zero_rdata_from_type(::Type{P}) where {P}
     R = rdata_type(tangent_type(P))
     R == NoRData && return true
-    isconcretetype(P) || return false
+    isabstracttype(P) && return false
+    (isconcretetype(P) || P <: Tuple) || return false
+    (P <: Tuple && Base.datatype_fieldcount(P) === nothing) && return false
 
     # For general structs, just look at their fields.
     return isstructtype(P) ? all(can_produce_zero_rdata_from_type, fieldtypes(P)) : false

--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -59,7 +59,7 @@ end
 _type(x) = x
 _type(x::CC.Const) = _typeof(x.val)
 _type(x::CC.PartialStruct) = x.typ
-_type(x::CC.Conditional) = Union{x.thentype, x.elsetype}
+_type(x::CC.Conditional) = Union{_type(x.thentype), _type(x.elsetype)}
 
 function CC.inlining_policy(
     interp::TapirInterpreter{C},

--- a/src/interpreter/ir_normalisation.jl
+++ b/src/interpreter/ir_normalisation.jl
@@ -138,8 +138,7 @@ end
 
 lift_intrinsic(x...) = x
 function lift_intrinsic(x::GlobalRef, args...)
-    val = getglobal(x.mod, x.name)
-    return val isa Core.IntrinsicFunction ? lift_intrinsic(val, args...) : (x, args...)
+    return lift_intrinsic(getglobal(x.mod, x.name), args...)
 end
 function lift_intrinsic(x::Core.IntrinsicFunction, v, args...)
     if x === cglobal
@@ -147,6 +146,9 @@ function lift_intrinsic(x::Core.IntrinsicFunction, v, args...)
     else
         return IntrinsicsWrappers.translate(Val(x)), v, args...
     end
+end
+function lift_intrinsic(::typeof(Core._apply_iterate), args...)
+    return _apply_iterate_equivalent, args...
 end
 
 """

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1129,7 +1129,7 @@ function DynamicDerivedRule(interp::TapirInterpreter, safety_on::Bool)
 end
 
 function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any, N}) where {N}
-    sig = signature_from_values(tuple_map(primal, args))
+    sig = Tuple{map(_typeof, args)...}
     is_primitive(context_type(dynamic_rule.interp), sig) && return rrule!!(args...)
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -786,19 +786,20 @@ function build_rrule(
     else
         fwds_ir = forwards_pass_ir(primal_ir, ad_stmts_blocks, info, _typeof(shared_data))
         pb_ir = pullback_ir(primal_ir, Treturn, ad_stmts_blocks, info, _typeof(shared_data))
+
+        optimised_fwds_ir = optimise_ir!(IRCode(fwds_ir); do_inline=true)
+        optimised_pb_ir = optimise_ir!(IRCode(pb_ir); do_inline=true)
         # @show sig
         # @show Treturn
         # @show safety_on
         # display(ir)
         # display(IRCode(fwds_ir))
         # display(IRCode(pb_ir))
-        optimised_fwds_ir = optimise_ir!(IRCode(fwds_ir); do_inline=true)
-        optimised_pb_ir = optimise_ir!(IRCode(pb_ir); do_inline=true)
+        # display(optimised_fwds_ir)
+        # display(optimised_pb_ir)
         # @show length(ir.stmts.inst)
         # @show length(optimised_fwds_ir.stmts.inst)
         # @show length(optimised_pb_ir.stmts.inst)
-        # display(optimised_fwds_ir)
-        # display(optimised_pb_ir)
         fwds_oc = OpaqueClosure(optimised_fwds_ir, shared_data...; do_compile=true)
         pb_oc = OpaqueClosure(optimised_pb_ir, shared_data...; do_compile=true)
         interp.oc_cache[(sig, safety_on)] = (fwds_oc, pb_oc)

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1129,7 +1129,7 @@ function DynamicDerivedRule(interp::TapirInterpreter, safety_on::Bool)
 end
 
 function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any, N}) where {N}
-    sig = Tuple{tuple_map(typeof, tuple_map(primal, args))...}
+    sig = signature_from_values(tuple_map(primal, args))
     is_primitive(context_type(dynamic_rule.interp), sig) && return rrule!!(args...)
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1109,7 +1109,7 @@ __switch_case(id::Int32, predecessor_id::Int32) = !(id === predecessor_id)
 @inline __deref_arg_rev_data_refs(arg_rev_data_refs...) = map(getindex, arg_rev_data_refs)
 
 #=
-    DynamicDerivedRule(interp::TapirInterpreter)
+    DynamicDerivedRule(interp::TapirInterpreter, safety_on::Bool)
 
 For internal use only.
 
@@ -1129,7 +1129,7 @@ function DynamicDerivedRule(interp::TapirInterpreter, safety_on::Bool)
 end
 
 function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any, N}) where {N}
-    sig = Tuple{tuple_map(_typeof, tuple_map(primal, args))...}
+    sig = Tuple{tuple_map(typeof, tuple_map(primal, args))...}
     is_primitive(context_type(dynamic_rule.interp), sig) && return rrule!!(args...)
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -786,7 +786,9 @@ function build_rrule(
     else
         fwds_ir = forwards_pass_ir(primal_ir, ad_stmts_blocks, info, _typeof(shared_data))
         pb_ir = pullback_ir(primal_ir, Treturn, ad_stmts_blocks, info, _typeof(shared_data))
-        # @show sig, safety_on
+        # @show sig
+        # @show Treturn
+        # @show safety_on
         # display(ir)
         # display(IRCode(fwds_ir))
         # display(IRCode(pb_ir))
@@ -1129,8 +1131,7 @@ function DynamicDerivedRule(interp::TapirInterpreter, safety_on::Bool)
 end
 
 function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any, N}) where {N}
-    sig = Tuple{map(_typeof, args)...}
-    is_primitive(context_type(dynamic_rule.interp), sig) && return rrule!!(args...)
+    sig = Tuple{map(_typeof ∘ primal, args)...}
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing
         rule = build_rrule(dynamic_rule.interp, sig; safety_on=dynamic_rule.safety_on)

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -972,28 +972,28 @@ function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:builtins})
             false, :none, nothing,
             x -> +(x...), randn(33),
         ),
-        # (
-        #     false, :none, nothing,
-        #     (
-        #         function (x)
-        #             rx = Ref(x)
-        #             pointerref(bitcast(Ptr{Float64}, pointer_from_objref(rx)), 1, 1)
-        #         end
-        #     ),
-        #     5.0,
-        # ),
-        # (
-        #     false, :none, nothing,
-        #     (v, x) -> (pointerset(pointer(x), v, 2, 1); x), 3.0, randn(5),
-        # ),
-        # (
-        #     false, :none, nothing,
-        #     x -> (pointerset(pointer(x), UInt8(3), 2, 1); x), rand(UInt8, 5),
-        # ),
-        # (false, :none, nothing, getindex, randn(5), [1, 1]),
-        # (false, :none, nothing, getindex, randn(5), [1, 2, 2]),
-        # (false, :none, nothing, setindex!, randn(5), [4.0, 5.0], [1, 1]),
-        # (false, :none, nothing, setindex!, randn(5), [4.0, 5.0, 6.0], [1, 2, 2]),
+        (
+            false, :none, nothing,
+            (
+                function (x)
+                    rx = Ref(x)
+                    pointerref(bitcast(Ptr{Float64}, pointer_from_objref(rx)), 1, 1)
+                end
+            ),
+            5.0,
+        ),
+        (
+            false, :none, nothing,
+            (v, x) -> (pointerset(pointer(x), v, 2, 1); x), 3.0, randn(5),
+        ),
+        (
+            false, :none, nothing,
+            x -> (pointerset(pointer(x), UInt8(3), 2, 1); x), rand(UInt8, 5),
+        ),
+        (false, :none, nothing, getindex, randn(5), [1, 1]),
+        (false, :none, nothing, getindex, randn(5), [1, 2, 2]),
+        (false, :none, nothing, setindex!, randn(5), [4.0, 5.0], [1, 1]),
+        (false, :none, nothing, setindex!, randn(5), [4.0, 5.0, 6.0], [1, 2, 2]),
     ]
     memory = Any[]
     return test_cases, memory

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -375,7 +375,7 @@ end
 
 # A function with the same semantics as `Core._apply_iterate`, but which is differentiable.
 function _apply_iterate_equivalent(itr, f::F, args::Vararg{Any, N}) where {F, N}
-    vec_args = reduce(vcat, tuple_map(collect, args))
+    vec_args = reduce(vcat, map(collect, args))
     tuple_args = __vec_to_tuple(vec_args)
     return tuple_splat(f, tuple_args)
 end
@@ -416,13 +416,6 @@ function build_rrule(
 )
     new_sig = Tuple{typeof(_apply_iterate_equivalent), sig.parameters[2:end]...}
     return ApplyIterateRule(build_rrule(interp, new_sig; kwargs...))
-end
-
-function rule_type(
-    interp::TapirInterpreter{C}, sig::Type{<:Tuple{typeof(Core._apply_iterate), Vararg}}
-) where {C}
-    new_sig = Tuple{typeof(_apply_iterate_equivalent), sig.parameters[2:end]...}
-    return ApplyIterateRule{rule_type(interp, new_sig)}
 end
 
 # Core._apply_pure

--- a/src/rrules/iddict.jl
+++ b/src/rrules/iddict.jl
@@ -51,6 +51,8 @@ fdata(t::IdDict) = t
 rdata_type(::Type{<:IdDict}) = NoRData
 rdata(t::IdDict) = NoRData()
 
+_verify_fdata_value(p::IdDict, f::IdDict) = nothing
+
 tangent_type(::Type{T}, ::Type{NoRData}) where {T<:IdDict} = T
 tangent(f::IdDict, ::NoRData) = f
 

--- a/src/safe_mode.jl
+++ b/src/safe_mode.jl
@@ -9,6 +9,8 @@ post-conditions to `pb`. Let `dx = pb.pb(dy)`, for some rdata `dy`, then this fu
 """
 struct SafePullback{Tpb, Ty, Tx}
     pb::Tpb
+    y::Ty
+    x::Tx
 end
 
 """
@@ -17,36 +19,29 @@ end
 Apply type checking to enforce pre- and post-conditions on `pb.pb`. See the docstring for
 `SafePullback` for details.
 """
-@inline function (pb::SafePullback{Tpb, Ty, Tx})(dy) where {Tpb, Ty, Tx}
-    verify_rvs_input(Ty, dy)
+@inline function (pb::SafePullback)(dy)
+    verify_rvs_input(pb.y, dy)
     dx = pb.pb(dy)
-    verify_rvs_output(Tx, dx)
+    verify_rvs_output(pb.x, dx)
     return dx
 end
 
-@noinline verify_rvs_input(::Type{Ty}, dy) where {Ty} = verify_rvs(Ty, dy)
+@noinline verify_rvs_input(y, dy) = verify_rdata_value(y, dy)
 
-@noinline function verify_rvs_output(::Type{Tx}, dx) where {Tx}
-    @nospecialize pb dx
+@noinline function verify_rvs_output(x, dx)
 
     # Number of arguments and number of elements in pullback must match. Have to check this
     # because `zip` doesn't require equal lengths for arguments.
-    l_pb = length(Tx.parameters)
+    l_pb = length(x)
     l_dx = length(dx)
     if l_pb != l_dx
         error("Number of args = $l_pb but number of rdata = $l_dx. They must to be equal.")
     end
 
     # Use for-loop to keep stack trace as simple as possible.
-    for (x, dx) in zip(Tx.parameters, dx)
-        verify_rvs(x, dx)
+    for (_x, _dx) in zip(x, dx)
+        verify_rdata_value(_x, _dx)
     end
-end
-
-@noinline function verify_rvs(::Type{P}, dx::R) where {P, R}
-    _R = rdata_type(tangent_type(P))
-    R <: ZeroRData && return nothing
-    (R <: _R) || throw(ArgumentError("Type $P has rdata type $_R, but got $R."))
 end
 
 """
@@ -84,7 +79,7 @@ for `SafeRRule` for details.
     verify_fwds_inputs(x)
     y, pb = rule.rule(x...)
     verify_fwds_output(x, y)
-    return y::CoDual, SafePullback{_typeof(pb), _typeof(primal(y)), Tuple{tuple_map(_typeof ∘ primal, x)...}}(pb)
+    return y::CoDual, SafePullback(pb, primal(y), map(primal, x))
 end
 
 @noinline function verify_fwds_inputs(@nospecialize(x::Tuple))
@@ -106,40 +101,4 @@ end
     end
 end
 
-@noinline function verify_fwds(x::CoDual{P, F}) where {P, F}
-    _fdata_type_checker(P, F)
-    verify_fwds_values(primal(x), tangent(x))
-end
-
-function verify_fwds_values(p::P, f::F) where {P, F}
-    _fdata_type_checker(P, F)
-    if F == NoFData
-        return
-    elseif P <: Array
-        if size(p) != size(f)
-            throw(ArgumentError("size of P is $(size(p)) but size of F is $(size(f))"))
-        end
-        isbitstype(eltype(P)) && return
-        for n in eachindex(p)
-            !isassigned(p, n) && continue
-            Fn = _typeof(f[n])
-            Pn = _typeof(p[n])
-            Tn = tangent_type(Pn)
-            if Fn != Tn
-                throw(ArgumentError(
-                    "the type of each element of an fdata Array must be the tangent_type " *
-                    "of the corresponding element of the primal array. Found that " *
-                    "element $n of fdata array is of type $Fn, while primal is of " *
-                    "type $Pn, whose tangent type is $Tn.",
-                ))
-            end
-        end
-    elseif isstructtype(P)
-        return
-    end
-end
-
-function _fdata_type_checker(P, F)
-    _F = fdata_type(tangent_type(P))
-    F == _F || throw(ArgumentError("type $P has fdata type $_F, but got $F."))
-end
+@noinline verify_fwds(x::CoDual) = verify_fdata_value(primal(x), tangent(x))

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -208,12 +208,27 @@ tangent_type(::Type{DimensionMismatch}) = NoTangent
 
 tangent_type(::Type{Method}) = NoTangent
 
+function is_concrete_or_typelike(P::DataType)
+    if P <: Tuple
+        P == Tuple && return false
+        return all(is_concrete_or_typelike, P.parameters)
+    elseif P <: DataType
+        return true
+    else
+        return isconcretetype(P)
+    end
+end
+
+is_concrete_or_typelike(::Union) = false
+is_concrete_or_typelike(::UnionAll) = false
+is_concrete_or_typelike(::Core.TypeofVararg) = true
+
 @generated function tangent_type(::Type{P}) where {P<:Tuple}
     isa(P, Union) && return Union{tangent_type(P.a), tangent_type(P.b)}
     isempty(P.parameters) && return NoTangent
     isa(last(P.parameters), Core.TypeofVararg) && return Any
     all(p -> tangent_type(p) == NoTangent, P.parameters) && return NoTangent
-    isconcretetype(P) || return Any
+    all(is_concrete_or_typelike, P.parameters) || return Any
     return Tuple{map(tangent_type, fieldtypes(P))...}
 end
 

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -219,7 +219,7 @@ function is_concrete_or_typelike(P::DataType)
     end
 end
 
-is_concrete_or_typelike(::Union) = false
+is_concrete_or_typelike(::Union) = true
 is_concrete_or_typelike(::UnionAll) = false
 is_concrete_or_typelike(::Core.TypeofVararg) = true
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -92,7 +92,9 @@ using Tapir:
     is_always_fully_initialised, get_tangent_field, set_tangent_field!, MutableTangent,
     Tangent, _typeof, rdata, NoFData, to_fwds, uninit_fdata, zero_rdata,
     zero_rdata_from_type, CannotProduceZeroRDataFromType, LazyZeroRData, instantiate,
-    can_produce_zero_rdata_from_type, increment_rdata!!, fcodual_type
+    can_produce_zero_rdata_from_type, increment_rdata!!, fcodual_type,
+    verify_fdata_type, verify_rdata_type, verify_fdata_value, verify_rdata_value,
+    InvalidFDataException, InvalidRDataException
 
 has_equal_data(x::T, y::T; equal_undefs=true) where {T<:String} = x == y
 has_equal_data(x::Type, y::Type; equal_undefs=true) = x == y
@@ -829,7 +831,7 @@ function test_equality_comparison(x)
 end
 
 """
-    test_fwds_rvs_data_interface(rng::AbstractRNG, p::P) where {P}
+    test_fwds_rvs_data(rng::AbstractRNG, p::P) where {P}
 
 Verify that the forwards data and reverse data functionality associated to primal `p` works
 correctly.
@@ -849,6 +851,17 @@ function test_fwds_rvs_data(rng::AbstractRNG, p::P) where {P}
     @test f isa F
     r = Tapir.rdata(t)
     @test r isa R
+
+    # Check that fdata / rdata validation functionality doesn't error on valid fdata / rdata
+    # and does error on obviously wrong fdata / rdata.
+    @test verify_fdata_type(P, F) === nothing
+    @test verify_rdata_type(P, R) === nothing
+    @test verify_fdata_value(p, f) === nothing
+    @test verify_rdata_value(p, r) === nothing
+    @test_throws InvalidFDataException verify_fdata_type(P, Int)
+    @test_throws InvalidRDataException verify_rdata_type(P, Int)
+    @test_throws InvalidFDataException verify_fdata_value(p, 0)
+    @test_throws InvalidRDataException verify_rdata_value(p, 0)
 
     # Check that uninit_fdata yields data of the correct type.
     @test uninit_fdata(p) isa F

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -44,6 +44,12 @@ function tuple_map(f::F, x::NamedTuple{names}, y::NamedTuple{names}) where {F, n
     return NamedTuple{names}(tuple_map(f, Tuple(x), Tuple(y)))
 end
 
+for N in 1:256
+    @eval @inline function tuple_splat(f, x::Tuple{Vararg{Any, $N}})
+        return $(Expr(:call, :f, map(n -> :(getfield(x, $n)), 1:N)...))
+    end
+end
+
 @inline @generated function tuple_splat(f, x::Tuple)
     return Expr(:call, :f, map(n -> :(x[$n]), 1:length(x.parameters))...)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,6 +8,13 @@ _typeof(x::Tuple) = Tuple{map(_typeof, x)...}
 _typeof(x::NamedTuple{names}) where {names} = NamedTuple{names, _typeof(Tuple(x))}
 
 """
+    signature_from_values(x::Tuple)
+
+
+"""
+signature_from_values(x::Tuple) = Tuple{map(Base._stable_typeof, x)...}
+
+"""
     tuple_map(f::F, x::Tuple) where {F}
 
 This function is largely equivalent to `map(f, x)`, but always specialises on all of

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,13 +8,6 @@ _typeof(x::Tuple) = Tuple{map(_typeof, x)...}
 _typeof(x::NamedTuple{names}) where {names} = NamedTuple{names, _typeof(Tuple(x))}
 
 """
-    signature_from_values(x::Tuple)
-
-
-"""
-signature_from_values(x::Tuple) = Tuple{map(Base._stable_typeof, x)...}
-
-"""
     tuple_map(f::F, x::Tuple) where {F}
 
 This function is largely equivalent to `map(f, x)`, but always specialises on all of

--- a/test/front_matter.jl
+++ b/test/front_matter.jl
@@ -56,7 +56,11 @@ using Tapir:
     new_inst,
     characterise_unique_predecessor_blocks,
     NoPullback,
-    characterise_used_ids
+    characterise_used_ids,
+    InvalidFDataException,
+    InvalidRDataException,
+    verify_fdata_value,
+    verify_rdata_value
 
 using .TestUtils:
     test_rrule!!,

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -10,10 +10,12 @@ end
         @test Tapir.can_produce_zero_rdata_from_type(Vector) == true
         @test Tapir.zero_rdata_from_type(Vector) == NoRData()
         @test Tapir.can_produce_zero_rdata_from_type(FwdsRvsDataTestResources.Foo) == false
+        @test Tapir.can_produce_zero_rdata_from_type(Tuple{Float64, Type{Float64}})
         @test ==(
             Tapir.zero_rdata_from_type(FwdsRvsDataTestResources.Foo),
             Tapir.CannotProduceZeroRDataFromType(),
         )
+        @test !Tapir.can_produce_zero_rdata_from_type(Tuple)
     end
     @testset "lazy construction checks" begin
         # Check that lazy construction is in fact lazy for some cases where performance

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -34,4 +34,39 @@ end
             @inferred Tapir.instantiate(LazyZeroRData(p))
         end
     end
+    @testset "misc fdata / rdata type checking" begin
+        @test(==(
+            Tapir.rdata_type(tangent_type(Tuple{Union{Float32, Float64}})),
+            Tuple{Union{Float32, Float64}},
+        ))
+        @test(==(
+            Tapir.rdata_type(tangent_type(Tuple{Union{Int32, Int}})), NoRData
+        ))
+        @test(==(
+            Tapir.rdata_type(tangent_type(
+                Tuple{Union{Vector{Float32}, Vector{Float64}}}
+            )),
+            NoRData,
+        ))
+    end
+
+    # Tests that the static type of an fdata / rdata is correct happen in
+    # test_fwds_rvs_data, so here we only need to test the specific quirks for a given type.
+    @testset "fdata and rdata verification" begin
+        @testset "Array" begin
+            @test_throws InvalidFDataException verify_fdata_value(randn(10), randn(11))
+            @test_throws InvalidFDataException verify_fdata_value([randn(10)], [randn(11)])
+            @test_throws InvalidFDataException verify_fdata_value(Any[1], [NoFData()])
+        end
+        @testset "Tuple" begin
+            @test_throws InvalidFDataException verify_fdata_value((), ())
+            @test_throws InvalidFDataException verify_fdata_value((5,), (NoFData(), ))
+            @test_throws InvalidRDataException verify_rdata_value((), ())
+            @test_throws InvalidRDataException verify_rdata_value((5,), (NoRData(), ))
+        end
+        @testset "Ptr" begin
+            @test verify_fdata_value(Ptr{Float64}(), Ptr{Float64}()) === nothing
+            @test verify_rdata_value(Ptr{Float64}(), NoRData()) === nothing
+        end
+    end
 end

--- a/test/integration_testing/turing.jl
+++ b/test/integration_testing/turing.jl
@@ -75,6 +75,14 @@ end
     #w ~ arraydist([dist[doc[i]] for i in 1:length(doc)])
 end
 
+function make_large_model(num_tildes::Int)
+    expr = :(function $(Symbol(:demo, num_tildes))() end) |> Base.remove_linenums!
+    mainbody = last(expr.args)
+    append!(mainbody.args, [:($(Symbol("x", j)) ~ Normal()) for j = 1:num_tildes])
+    f = @eval $(DynamicPPL.model(:Main, LineNumberNode(1), expr, false))
+    return invokelatest(f)
+end
+
 function build_turing_problem(rng, model, example=nothing)
     ctx = Turing.DefaultContext()
     vi = example === nothing ? Turing.SimpleVarInfo(model) : Turing.SimpleVarInfo(example)
@@ -89,14 +97,15 @@ end
     interp = Tapir.PInterp()
     @testset "$(typeof(model))" for (interface_only, name, model, ex) in vcat(
         Any[
-            (false, "simple_model", simple_model(), nothing),
-            (false, "demo", demo(), nothing),
-            (
-                false,
-                "broadcast_demo",
-                broadcast_demo(rand(LogNormal(1.5, 0.5), 1_000)),
-                nothing,
-            ),
+            # (false, "simple_model", simple_model(), nothing),
+            # (false, "demo", demo(), nothing),
+            # (
+            #     false,
+            #     "broadcast_demo",
+            #     broadcast_demo(rand(LogNormal(1.5, 0.5), 1_000)),
+            #     nothing,
+            # ),
+            (false, "large model", make_large_model(33), nothing),
             # (
             #     false,
             #     "CollapsedLDA",
@@ -105,50 +114,50 @@ end
             #     ),
             # ), doesn't currently work with SimpleVarInfo
         ],
-        Any[
-            (false, "demo_$n", m, Turing.DynamicPPL.TestUtils.rand_prior_true(m)) for
-                (n, m) in enumerate(Turing.DynamicPPL.TestUtils.DEMO_MODELS)
-        ],
+        # Any[
+        #     (false, "demo_$n", m, Turing.DynamicPPL.TestUtils.rand_prior_true(m)) for
+        #         (n, m) in enumerate(Turing.DynamicPPL.TestUtils.DEMO_MODELS)
+        # ],
     )
         @info name
         rng = sr(123)
         f, x = build_turing_problem(rng, model, ex)
         TestUtils.test_derived_rule(
             sr(123456), f, x;
-            perf_flag=:none, interface_only=true, is_primitive=false, interp
+            perf_flag=:none, interface_only=true, is_primitive=false, interp, safety_on=true
         )
 
-        # rule = build_rrule(interp, _typeof((f, x)))
-        # codualed_args = map(zero_codual, (f, x))
-        # TestUtils.to_benchmark(rule, codualed_args...)
+        rule = build_rrule(interp, _typeof((f, x)))
+        codualed_args = map(zero_codual, (f, x))
+        TestUtils.to_benchmark(rule, codualed_args...)
 
-        # primal = @benchmark $f($x)
-        # gradient = @benchmark(TestUtils.to_benchmark($rule, $codualed_args...))
+        primal = @benchmark $f($x)
+        gradient = @benchmark(TestUtils.to_benchmark($rule, $codualed_args...))
 
-        # println("primal")
-        # display(primal)
-        # println()
+        println("primal")
+        display(primal)
+        println()
 
-        # println("gradient")
-        # display(gradient)
-        # println()
+        println("gradient")
+        display(gradient)
+        println()
 
-        # try
-        #     tape = ReverseDiff.GradientTape(f, x);
-        #     ReverseDiff.gradient!(tape, x);
-        #     result = zeros(size(x));
-        #     ReverseDiff.gradient!(result, tape, x)
+        try
+            tape = ReverseDiff.GradientTape(f, x);
+            ReverseDiff.gradient!(tape, x);
+            result = zeros(size(x));
+            ReverseDiff.gradient!(result, tape, x)
 
-        #     revdiff = @benchmark ReverseDiff.gradient!($result, $tape, $x)
-        #     println("ReverseDiff")
-        #     display(revdiff)
-        #     println()
-        #     @show time(revdiff) / time(primal)
-        # catch
-        #     display("revdiff failed")
-        # end
+            revdiff = @benchmark ReverseDiff.gradient!($result, $tape, $x)
+            println("ReverseDiff")
+            display(revdiff)
+            println()
+            @show time(revdiff) / time(primal)
+        catch
+            display("revdiff failed")
+        end
 
-        # @show time(gradient) / time(primal)
+        @show time(gradient) / time(primal)
 
         # @profview run_many_times(10_000, TestUtils.to_benchmark, rule, codualed_args...)
 

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -183,20 +183,6 @@ end
         end
     end
 
-    @testset "DynamicDerivedRule" begin
-        # Just check that this runs. You cannot look up the code for generated functions for
-        # non-concrete argument types. This example creates a setting in which
-        # `Tapir._typeof` creates the abstract `Type{AbstractFloat}`, but `typeof` creates
-        # the concrete `DataType`.
-        rule = Tapir.DynamicDerivedRule(Tapir.PInterp(), false)
-        output = rule(
-            zero_fcodual(Tapir.tuple_map),
-            zero_fcodual(typeof),
-            zero_fcodual((AbstractFloat, )),
-        )
-        @test(isa(output, Tuple))
-    end
-
     interp = Tapir.PInterp()
     @testset "$(_typeof((f, x...)))" for (n, (interface_only, perf_flag, bnds, f, x...)) in
         collect(enumerate(TestResources.generate_test_functions()))

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -183,6 +183,20 @@ end
         end
     end
 
+    @testset "DynamicDerivedRule" begin
+        # Just check that this runs. You cannot look up the code for generated functions for
+        # non-concrete argument types. This example creates a setting in which
+        # `Tapir._typeof` creates the abstract `Type{AbstractFloat}`, but `typeof` creates
+        # the concrete `DataType`.
+        rule = Tapir.DynamicDerivedRule(Tapir.PInterp(), false)
+        output = rule(
+            zero_fcodual(Tapir.tuple_map),
+            zero_fcodual(typeof),
+            zero_fcodual((AbstractFloat, )),
+        )
+        @test(isa(output, Tuple))
+    end
+
     interp = Tapir.PInterp()
     @testset "$(_typeof((f, x...)))" for (n, (interface_only, perf_flag, bnds, f, x...)) in
         collect(enumerate(TestResources.generate_test_functions()))

--- a/test/safe_mode.jl
+++ b/test/safe_mode.jl
@@ -22,12 +22,12 @@
 
     # Test that bad rdata is caught as a pre-condition.
     y, pb!! = Tapir.SafeRRule(rrule!!)(zero_fcodual(sin), zero_fcodual(5.0))
-    @test_throws(ArgumentError, pb!!(5))
+    @test_throws(InvalidRDataException, pb!!(5))
 
     # Test that bad rdata is caught as a post-condition.
     rule_with_bad_pb(x::CoDual{Float64}) = x, dy -> (5, ) # returns the wrong type
     y, pb!! = Tapir.SafeRRule(rule_with_bad_pb)(zero_fcodual(5.0))
-    @test_throws ArgumentError pb!!(1.0)
+    @test_throws InvalidRDataException pb!!(1.0)
 
     # Test that bad rdata is caught as a post-condition.
     rule_with_bad_pb_length(x::CoDual{Float64}) = x, dy -> (5, 5.0) # returns the wrong type

--- a/test/tangents.jl
+++ b/test/tangents.jl
@@ -84,6 +84,19 @@
     # not possible to properly test tangents because you can't separately specify the
     # static and dynamic types.
     @testset "extra tuple tests" begin
+        @testset "is_concrete_or_typelike" begin
+            @test Tapir.is_concrete_or_typelike(Float64)
+            @test !Tapir.is_concrete_or_typelike(Any)
+            @test Tapir.is_concrete_or_typelike(Type{Float64})
+            @test Tapir.is_concrete_or_typelike(DataType)
+            @test Tapir.is_concrete_or_typelike(Tuple{})
+            @test Tapir.is_concrete_or_typelike(Tuple{Float64})
+            @test Tapir.is_concrete_or_typelike(Tuple{Float64, Type{Float64}})
+            @test Tapir.is_concrete_or_typelike(Tuple{Float64, Tuple{Type{Float64}}})
+            @test !Tapir.is_concrete_or_typelike(Tuple)
+            @test !Tapir.is_concrete_or_typelike(Union{Float64, Float32})
+            @test !Tapir.is_concrete_or_typelike(Tuple{T} where {T<:Any})
+        end
         @test tangent_type(Tuple) == Any
         @test tangent_type(Tuple{}) == NoTangent
         @test tangent_type(Tuple{Float64, Vararg}) == Any
@@ -91,6 +104,8 @@
         @test tangent_type(Tuple{Float64, Int}) == Tuple{Float64, NoTangent}
         @test tangent_type(Tuple{Int, Int}) == NoTangent
         @test tangent_type(Tuple{DataType, Type{Float64}}) == NoTangent
+        @test tangent_type(Tuple{Type{Float64}, Float64}) == Tuple{NoTangent, Float64}
+        @test tangent_type(Tuple{Tuple{Type{Int}}, Float64}) == Tuple{NoTangent, Float64}
         @test ==(
             tangent_type(Union{Tuple{Float64}, Tuple{Int}}),
             Union{Tuple{Float64}, NoTangent},

--- a/test/tangents.jl
+++ b/test/tangents.jl
@@ -94,7 +94,7 @@
             @test Tapir.is_concrete_or_typelike(Tuple{Float64, Type{Float64}})
             @test Tapir.is_concrete_or_typelike(Tuple{Float64, Tuple{Type{Float64}}})
             @test !Tapir.is_concrete_or_typelike(Tuple)
-            @test !Tapir.is_concrete_or_typelike(Union{Float64, Float32})
+            @test Tapir.is_concrete_or_typelike(Union{Float64, Float32})
             @test !Tapir.is_concrete_or_typelike(Tuple{T} where {T<:Any})
         end
         @test tangent_type(Tuple) == Any


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
I'm slowly working through a few problems that arise when type instabilities appear for large SimpleVarInfo models. Many were previously resolved by dealing with splatnew and _apply_iterate. I'll remove the WIP label when this is ready to be merged.

I'm trying to be careful while going through to figure out what the underlying problem is for each failure, isolate it, unit test it, and fix it, as these won't be Turing-specific.

update: this now just about works, but something else has broken. Said break hasn't been picked up as it ought to be by the safe mode checks (it errors later than it ought to), so I'm going to spend tomorrow improving that quality of the checks performed as part of safe mode.