### PR TITLE
Safe mode warning with LogDensityProblemsAD and GP testing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.19"
+version = "0.2.20"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/TapirLogDensityProblemsADExt.jl
+++ b/ext/TapirLogDensityProblemsADExt.jl
@@ -57,6 +57,13 @@ function logdensity_and_gradient(∇l::TapirGradientLogDensity, x::Vector{Float6
 end
 
 # Interop with ADTypes.
-ADgradient(x::ADTypes.AutoTapir, ℓ) = ADgradient(Val(:Tapir), ℓ; safety_on=x.safe_mode)
+function ADgradient(x::ADTypes.AutoTapir, ℓ)
+    if x.safe_mode
+        msg = "Running Tapir in safe mode. Disable for best performance. Do this by " *
+            "using AutoTapir(safe_mode=false)."
+        @info msg
+    end
+    return ADgradient(Val(:Tapir), ℓ; safety_on=x.safe_mode)
+end
 
 end

--- a/test/integration_testing/gp.jl
+++ b/test/integration_testing/gp.jl
@@ -20,7 +20,7 @@ using AbstractGPs, KernelFunctions
         RowVecs(randn(9, 4)),
     ]
     d_2_xs = Any[ColVecs(randn(2, 11)), RowVecs(randn(9, 2))]
-    @testset "kernelmatrix_diag $k, $(typeof(x1))" for (k, x1) in vcat(
+    @testset "$k, $(typeof(x1))" for (k, x1) in vcat(
         Any[(k, x) for k in base_kernels for x in simple_xs],
         Any[(with_lengthscale(k, 1.1), x) for k in base_kernels for x in simple_xs],
         Any[(with_lengthscale(k, rand(2)), x) for k in base_kernels for x in d_2_xs],
@@ -30,19 +30,19 @@ using AbstractGPs, KernelFunctions
                 k in base_kernels for x in d_2_xs
         ],
     )
-        @info typeof(k), typeof(x1)
         fx = GP(k)(x1, 1.1)
         @testset "$(_typeof(x))" for x in Any[
             (kernelmatrix, k, x1, x1),
             (kernelmatrix_diag, k, x1, x1),
-            (kernelmatrix, x1),
-            (kernelmatrix_diag, x1),
+            (kernelmatrix, k, x1),
+            (kernelmatrix_diag, k, x1),
             (rand, Xoshiro(123456), fx),
             (logpdf, fx, rand(fx)),
         ]
+            @info typeof(x)
             TestUtils.test_derived_rule(
-                sr(123456), rand, Xoshiro(123456), GP(k)(x1, 1.1);
-                interp, perf_flag=:none, interface_only=true, is_primitive=false,
+                sr(123456), x...;
+                interp, perf_flag=:none, interface_only=false, is_primitive=false,
             )
         end
     end

--- a/test/integration_testing/gp.jl
+++ b/test/integration_testing/gp.jl
@@ -42,7 +42,7 @@ using AbstractGPs, KernelFunctions
             @info typeof(x)
             TestUtils.test_derived_rule(
                 sr(123456), x...;
-                interp, perf_flag=:none, interface_only=false, is_primitive=false,
+                interp, perf_flag=:none, interface_only=true, is_primitive=false,
             )
         end
     end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Prints the following when running in safe mode in LogDensityProblemsAD via AutoTapir:
```julia
julia> @time sample(Xoshiro(123456), m_post, NUTS(; adtype=AutoTapir(safe_mode=true)), 1_000)
[ Info: Running Tapir in safe mode. Disable for best performance. Do this by using AutoTapir(safe_mode=false).
```

This is in the context of me running a Turing.jl model.

Also fixes some integration tests for GPs which weren't previously running properly.